### PR TITLE
Add more Epson printer drivers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apk update && apk add -y \
 	cups-pdf \
   	cups-bsd \
   	cups-filters \
+	epson-inkjet-printer-escpr \
 	hplip \
 	inotify-tools \
 	foomatic-db-compressed-ppds \


### PR DESCRIPTION
Hi there! 

I was very glad to see this project maintained since the original RagingTiger was starting to be a bit ancient :)

My new printer Epson ET-2810 unfortunately doesn't work with the provided drivers, I have found that adding `epson-inkjet-printer-escpr` helps a lot, was wondering if you'd be okay adding it :)

Thanks for considering!